### PR TITLE
TEIID-5590

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,11 +121,6 @@
       <version>4.8.2</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-archiver</artifactId>
-      <version>3.4</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
       <version>4.8.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-archiver</artifactId>
+      <version>3.4</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/teiid/VdbMojo.java
+++ b/src/main/java/org/teiid/VdbMojo.java
@@ -79,6 +79,9 @@ public class VdbMojo extends AbstractMojo {
     @Parameter
     private File[] includes;
 
+    @Parameter(defaultValue = "${project.build.outputDirectory}", required = true)
+    private File classesDirectory;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 
@@ -99,6 +102,7 @@ public class VdbMojo extends AbstractMojo {
 
                 // add config, classes, lib and META-INF directories
                 Set<File> directories = new LinkedHashSet<>();
+                gatherContents(this.classesDirectory, directories);
                 gatherContents(this.vdbFolder, directories);
 
                 // do not allow vdb-import in the case of VDB represented with .ddl
@@ -168,7 +172,7 @@ public class VdbMojo extends AbstractMojo {
                         }
                     }
                 }
-                add(archive, "", directories.toArray(new File[directories.size()]));
+                add(archive, "", directories.toArray(new File[0]));
 
                 File finalVDB = new File(this.outputDirectory.getPath(), "vdb.xml");
                 finalVDB.getParentFile().mkdirs();

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -15,18 +15,6 @@
                  <process-resources>
                    org.apache.maven.plugins:maven-resources-plugin:resources
                  </process-resources>
-<!--                 <compile>
-                    org.apache.maven.plugins:maven-compiler-plugin:compile
-                 </compile>
-                 <process-test-resources>
-                    org.apache.maven.plugins:maven-resources-plugin:testResources
-                 </process-test-resources>
-                 <test-compile>
-                   org.apache.maven.plugins:maven-compiler-plugin:testCompile
-                 </test-compile>
-                 <test>
-                   org.apache.maven.plugins:maven-surefire-plugin:test
-                 </test>-->
                  <package>
                    org.teiid:vdb-maven-plugin:vdb
                  </package>

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -1,4 +1,4 @@
- <?xml version="1.0"?>
+<?xml version="1.0"?>
 <component-set>
   <components>
     <component>
@@ -12,11 +12,10 @@
             <lifecycle>
                <id>default</id>
                <phases>
-                <!-- 
                  <process-resources>
                    org.apache.maven.plugins:maven-resources-plugin:resources
                  </process-resources>
-                 <compile>
+<!--                 <compile>
                     org.apache.maven.plugins:maven-compiler-plugin:compile
                  </compile>
                  <process-test-resources>
@@ -27,8 +26,7 @@
                  </test-compile>
                  <test>
                    org.apache.maven.plugins:maven-surefire-plugin:test
-                 </test>
-                  -->
+                 </test>-->
                  <package>
                    org.teiid:vdb-maven-plugin:vdb
                  </package>


### PR DESCRIPTION
* Plexus components.xml should default to running the process-resources
  phase with plugin:goal of maven-resources-plugin:resources.

This is very apparent when trying to build a teiid-thorntail uber jar - without process-resources, none of the YAML files in `src/main/resources` are available on the classpath at runtime.