### PR TITLE
Added support for ~includes~ path configuration.

### DIFF
--- a/src/main/java/org/teiid/VdbMojo.java
+++ b/src/main/java/org/teiid/VdbMojo.java
@@ -105,6 +105,10 @@ public class VdbMojo extends AbstractMojo {
                 gatherContents(this.classesDirectory, directories);
                 gatherContents(this.vdbFolder, directories);
 
+                if (includes != null) {
+                    add(archive, "", includes);
+                }
+
                 // do not allow vdb-import in the case of VDB represented with .ddl
                 if (vdb.getName().endsWith("-vdb.ddl")) {
                     addFile(archive, "META-INF/vdb.ddl", vdb);
@@ -269,7 +273,7 @@ public class VdbMojo extends AbstractMojo {
             if (file.isDirectory()) {
                 this.add(archive, name + SLASH, Objects.requireNonNull(file.listFiles()));
             } else {
-                if (!name.endsWith("vdb.xml")) {
+                if (!name.endsWith("vdb.xml") && !name.endsWith("vdb.ddl")) {
                     addFile(archive, name, file);
                 }
             }


### PR DESCRIPTION
Added support for `includes` path configuration.
```
<configuration>
	<includes>
		<include>src/main/vdb</include>
	</includes>
</configuration>
```

This syntax enables the ability to create a .vdb file containing additional files other than the main vdb.ddl file, thus supporting the DDL syntax below:
```IMPORT FROM REPOSITORY "DDL-FILE" INTO public OPTIONS ("ddl-file" '/additional-vdb-schema.ddl');```

This behavior is supported by the 1.4.0 version of the teiid-spring-boot-starter, and the DDL syntax is described in https://teiid.github.io/teiid-documents/master/content/reference/r_ddl-deployment-mode.html#_importing_schema